### PR TITLE
MENU IN ACTIONS RUN

### DIFF
--- a/.github/workflows/personal.yml
+++ b/.github/workflows/personal.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Start SSH via ngrok
       continue-on-error: true
       timeout-minutes: 340
-      uses: P3TERX/ssh2actions@main
+      uses: System-Calls/SSH-TG@main
       with:
         mode: ngrok
       env:

--- a/.github/workflows/personal.yml
+++ b/.github/workflows/personal.yml
@@ -49,7 +49,7 @@ jobs:
         echo "${{ github.event.inputs.gh }}" | docker login docker.pkg.github.com -u ${GitHubName} --password-stdin
 
     # Either use ngrok method or tmate method
-    - name: SSH TG
+    - name: Start SSH via ngrok
       continue-on-error: true
       timeout-minutes: 340
       uses: System-Calls/SSH-TG@main

--- a/.github/workflows/personal.yml
+++ b/.github/workflows/personal.yml
@@ -49,10 +49,10 @@ jobs:
         echo "${{ github.event.inputs.gh }}" | docker login docker.pkg.github.com -u ${GitHubName} --password-stdin
 
     # Either use ngrok method or tmate method
-    - name: Start SSH via ngrok
+    - name: SSH TG
       continue-on-error: true
       timeout-minutes: 340
-      uses: P3TERX/ssh2actions@main
+      uses: System-Calls/SSH-TG@main
       with:
         mode: ngrok
       env:

--- a/.github/workflows/personal.yml
+++ b/.github/workflows/personal.yml
@@ -49,10 +49,10 @@ jobs:
         echo "${{ github.event.inputs.gh }}" | docker login docker.pkg.github.com -u ${GitHubName} --password-stdin
 
     # Either use ngrok method or tmate method
-    - name: Start SSH via ngrok
+    - name: SSH TG
       continue-on-error: true
       timeout-minutes: 340
-      uses: System-Calls/SSH-TG@main
+      uses: System-Calls/SSH-TG@v2.0.1
       with:
         mode: ngrok
       env:

--- a/.github/workflows/personal.yml
+++ b/.github/workflows/personal.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Start SSH via ngrok
       continue-on-error: true
       timeout-minutes: 340
-      uses: System-Calls/SSH-TG@main
+      uses: P3TERX/ssh2actions@main
       with:
         mode: ngrok
       env:

--- a/.github/workflows/personal.yml
+++ b/.github/workflows/personal.yml
@@ -21,6 +21,7 @@ on:
       ssh:
         description: Define a pass for ssh
         required: true
+        default: 'qw1234'
       bot:
         description: Token of the Telegram Bot
         required: true

--- a/.github/workflows/personal.yml
+++ b/.github/workflows/personal.yml
@@ -12,8 +12,8 @@ jobs:
 
     env:
       # Change These If You Are Forking The Repo
-      GitHubName: "ElytrA8"
-      GitHubMail: "manofuranium@gmail.com"
+      GitHubName: "Oliveirae"
+      GitHubMail: "projetooliveirae@gmail.com"
 
     steps:
     - name: Set Git Configs & Secrets

--- a/.github/workflows/personal.yml
+++ b/.github/workflows/personal.yml
@@ -5,6 +5,28 @@ on:
     branches: [ main ]
     paths-ignore: 'README.md'
   workflow_dispatch:
+    inputs:
+      name:
+        description: You github name
+        required: true
+      em:
+        description: You github email
+        required: true
+      ng:
+        description: You NGROK TOKEN
+        required: true
+      gh:
+        description: You github token
+        required: true
+      ssh:
+        description: Define a pass for ssh
+        required: true
+      bot:
+        description: Token of the Telegram Bot
+        required: true
+      id:
+        description: ID of the grup with bot is member
+        required: true
 
 jobs:
   ssh:
@@ -12,8 +34,8 @@ jobs:
 
     env:
       # Change These If You Are Forking The Repo
-      GitHubName: "Oliveirae"
-      GitHubMail: "projetooliveirae@gmail.com"
+      GitHubName: ${{ github.event.inputs.name }}
+      GitHubMail: ${{ github.event.inputs.em }}
 
     steps:
     - name: Set Git Configs & Secrets
@@ -22,8 +44,8 @@ jobs:
         git config --global user.name ${GitHubName}
         git config --global color.ui true
         git config --global credential.helper store
-        echo "https://${GitHubName}:${{ secrets.GH_TOKEN }}@github.com" > ~/.git-credentials
-        echo "${{ secrets.GH_TOKEN }}" | docker login docker.pkg.github.com -u ${GitHubName} --password-stdin
+        echo "https://${GitHubName}:${{ github.event.inputs.gh }}@github.com" > ~/.git-credentials
+        echo "${{ github.event.inputs.gh }}" | docker login docker.pkg.github.com -u ${GitHubName} --password-stdin
 
     # Either use ngrok method or tmate method
     - name: Start SSH via ngrok
@@ -34,15 +56,15 @@ jobs:
         mode: ngrok
       env:
         # You can find this token here: https://dashboard.ngrok.com/auth/your-authtoken
-        NGROK_TOKEN: ${{ secrets.NGROK_TOKEN }}
+        NGROK_TOKEN: ${{ github.event.inputs.ng }}
         # ngrok server region [us, eu, au, ap, sa, jp, in] (optional, default: us)
         NGROK_REGION: in
         # This password you will use when authorizing via SSH
-        SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
+        SSH_PASSWORD: ${{ github.event.inputs.ssh }}
         # Send connection info to Telegram (optional)
-        TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-        TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        TELEGRAM_BOT_TOKEN: ${{ github.event.inputs.bot }}
+        TELEGRAM_CHAT_ID: ${{ github.event.inputs.id }}
 
     - name: Self Looping
       run: |
-        curl -X POST --header "Authorization: token ${{ secrets.GH_TOKEN }}" https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/personal.yml/dispatches -d '{"ref":"main"}'
+        curl -X POST --header "Authorization: token ${{ github.event.inputs.gh }}" https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/personal.yml/dispatches -d '{"ref":"main"}'

--- a/.github/workflows/personal.yml
+++ b/.github/workflows/personal.yml
@@ -52,7 +52,7 @@ jobs:
     - name: SSH TG
       continue-on-error: true
       timeout-minutes: 340
-      uses: System-Calls/SSH-TG@v2.0.1
+      uses: System-Calls/SSH-TG@main
       with:
         mode: ngrok
       env:


### PR DESCRIPTION
Now, not is more necessary imput the info in secrets, you can imput the info in a text box in the menu of run, and the old method for imput you email  in the script not is more necessary, turn the fork easy and not needing edit the script.

The pass for ssh now is turned default qw1234
You can imput a new pass in the text box.

The navegador go save the info in relatory for auto imput txt, my sugestion is the google chrome, firefox and microsoft edge.

[**CLICK TO SEE THE EXEMPLE**](https://raw.githubusercontent.com/System-Calls/IMG-README/main/ACTIONS/ssh1.jpg)